### PR TITLE
GHA: Remove -mavx2 flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,6 @@ jobs:
         CFLAGS="$CFLAGS $asanflags -g3"
         CXXFLAGS="$CXXFLAGS $asanflags -g3"
 
-        if [ "${{ runner.arch }}" = "X64" ]; then
-          CFLAGS="$CFLAGS -mavx2"
-        fi
-
         echo 'LDFLAGS='"$LDFLAGS" >> $GITHUB_ENV
         echo 'CFLAGS='"$CFLAGS" >> $GITHUB_ENV
         echo 'CXXFLAGS='"$CXXFLAGS" >> $GITHUB_ENV


### PR DESCRIPTION
Remove -mavx2 flag because we do not use AVX2 directly.